### PR TITLE
Fix variable names both in README & commentary.

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@
   '(progn
      (require 'japanese-holidays)
      (setq calendar-holidays ; 他の国の祝日も表示させたい場合は適当に調整
-           (append japanese-holidays local-holidays other-holidays))
+           (append japanese-holidays holiday-local-holidays holiday-other-holidays))
      (setq mark-holidays-in-calendar t) ; 祝日をカレンダーに表示
      ;; 土曜日・日曜日を祝日として表示する場合、以下の設定を追加します。
      ;; デフォルトで設定済み

--- a/japanese-holidays.el
+++ b/japanese-holidays.el
@@ -41,7 +41,7 @@
 ;;   '(progn
 ;;      (require 'japanese-holidays)
 ;;      (setq calendar-holidays ; 他の国の祝日も表示させたい場合は適当に調整
-;;            (append japanese-holidays local-holidays other-holidays))
+;;            (append japanese-holidays holiday-local-holidays holiday-other-holidays))
 ;;      (setq mark-holidays-in-calendar t) ; 祝日をカレンダーに表示
 ;;      ;; 土曜日・日曜日を祝日として表示する場合、以下の設定を追加します。
 ;;      ;; 変数はデフォルトで設定済み


### PR DESCRIPTION
The variables suggested previously don't exist in Emacs (at least in the current version 24.4). I assumed it to be typo.

Thanks to all emacs-jp team for hosting the package here and bringing life to it again.
