### PR TITLE
Use variable calendar-mark-holidays-flag instead of mark-holidays-in-calendar

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,7 @@
      (require 'japanese-holidays)
      (setq calendar-holidays ; 他の国の祝日も表示させたい場合は適当に調整
            (append japanese-holidays holiday-local-holidays holiday-other-holidays))
-     (setq mark-holidays-in-calendar t) ; 祝日をカレンダーに表示
+     (setq calendar-mark-holidays-flag t) ; 祝日をカレンダーに表示
      ;; 土曜日・日曜日を祝日として表示する場合、以下の設定を追加します。
      ;; デフォルトで設定済み
      (setq japanese-holiday-weekend '(0 6)     ; 土日を祝日として表示


### PR DESCRIPTION
GNU Emacs 23.1 において mark-holidays-in-calendar は obsolete とされ、新たに calendar-mark-holidays-flag となりました。
その後 commit 3f6597 によって mark-holidays-in-calendar は削除されています。