### PR TITLE
fix sample settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 `~/.emacs.d/init.el` に以下の設定を追加します。
 
 ```elisp
-(with-eval-after-load "holidays"
+(with-eval-after-load "calendar"
   (require 'japanese-holidays)
   (setq calendar-holidays ; 他の国の祝日も表示させたい場合は適当に調整
         (append japanese-holidays holiday-local-holidays holiday-other-holidays))

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 `~/.emacs.d/init.el` に以下の設定を追加します。
 
 ```elisp
-(setq calendar-mark-holidays-flag t)	; 祝日をカレンダーに表示
 (with-eval-after-load "holidays"
   (require 'japanese-holidays)
   (setq calendar-holidays ; 他の国の祝日も表示させたい場合は適当に調整
         (append japanese-holidays holiday-local-holidays holiday-other-holidays))
+  (setq calendar-mark-holidays-flag t)	; 祝日をカレンダーに表示
   ;; 土曜日・日曜日を祝日として表示する場合、以下の設定を追加します。
   ;; デフォルトで設定済み
   (setq japanese-holiday-weekend '(0 6)	   ; 土日を祝日として表示

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 `~/.emacs.d/init.el` に以下の設定を追加します。
 
 ```elisp
+(setq calendar-mark-holidays-flag t)	; 祝日をカレンダーに表示
 (with-eval-after-load "holidays"
   (require 'japanese-holidays)
   (setq calendar-holidays ; 他の国の祝日も表示させたい場合は適当に調整
         (append japanese-holidays holiday-local-holidays holiday-other-holidays))
-  (setq calendar-mark-holidays-flag t)	; 祝日をカレンダーに表示
   ;; 土曜日・日曜日を祝日として表示する場合、以下の設定を追加します。
   ;; デフォルトで設定済み
   (setq japanese-holiday-weekend '(0 6)	   ; 土日を祝日として表示

--- a/japanese-holidays.el
+++ b/japanese-holidays.el
@@ -36,7 +36,7 @@
 ;;
 ;; Following is an example of using this utility.
 
-;; (eval-after-load "holidays"
+;; (eval-after-load "calendar"
 ;;   '(progn
 ;;      (require 'japanese-holidays)
 ;;      (setq calendar-holidays ; 他の国の祝日も表示させたい場合は適当に調整


### PR DESCRIPTION
Getting Started の通りの設定をしたところ、<kbd>M-x calendar</kbd> で祝日が表示されなかったので設定を修正しました。

# 再現方法

## Emacs のバージョン

Emacs 27.1

## 再現手順

```shell
$ cat init.el
(require 'package)

(setq package-archives
      '(("melpa" . "https://melpa.org/packages/")))

(package-initialize)

(package-refresh-contents)

(package-install 'japanese-holidays)

(with-eval-after-load "holidays"
  (require 'japanese-holidays)
  (setq calendar-holidays ; 他の国の祝日も表示させたい場合は適当に調整
        (append japanese-holidays holiday-local-holidays holiday-other-holidays))
  (setq calendar-mark-holidays-flag t)	; 祝日をカレンダーに表示
  ;; 土曜日・日曜日を祝日として表示する場合、以下の設定を追加します。
  ;; デフォルトで設定済み
  (setq japanese-holiday-weekend '(0 6)	   ; 土日を祝日として表示
        japanese-holiday-weekend-marker	   ; 土曜日を水色で表示
        '(holiday nil nil nil nil nil japanese-holiday-saturday))
  (add-hook 'calendar-today-visible-hook 'japanese-holiday-mark-weekend)
  (add-hook 'calendar-today-invisible-hook 'japanese-holiday-mark-weekend))
```
```sh
$ emacs -Q -l init.el
```

上記の方法で起動した Emacs で、起動直後に <kbd>M-x calendar</kbd> すると、祝日が表示されませんでした。

<kbd>M-x list-holidays</kbd> などを実行して、holidays パッケージが読み込まれた後だと、<kbd>M-x calendar</kbd> で祝日が表示されるようです。

この PR では ` (setq calendar-mark-holidays-flag t)` の記述を `(with-eval-after-load "holidays" ...)`  の外側に出すことで上記の問題に対処しています。

日本語でごめんなさい。ご確認よろしくお願いします。